### PR TITLE
Rather dirty hack to automatically reopen a lost serial interface.

### DIFF
--- a/kplex.h
+++ b/kplex.h
@@ -210,6 +210,7 @@ struct iface {
     void (*read)(struct iface *);
     void (*write)(struct iface *);
     ssize_t (*readbuf)(struct iface *,char *buf);
+    void (*reopen)(struct iface *);
 };
 
 typedef struct iface iface_t;


### PR DESCRIPTION
As proposed in forum, a modification to allow a lost serial connection to be re-established. It is dirty in the sense that it will most likely not work for interfaces also used as output (since the reopen cannot be done on the companion fd without close studying / reworking of the data structures).
