### PR TITLE
fix make file for debian/ubuntu packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,20 @@ else
 BASE_VERSION := $(shell cat base_version)
 endif
 ifeq ($(OS),Linux)
-DESTDIR?=/usr
+PREFIX?=/usr
+MANDIR?=$(PREFIX)/share/man
 LDLIBS?=-pthread -lutil
 INSTGROUP?=root
 else
-DESTDIR?=/usr/local
-MANDIR?=$(DESTDIR)/man
+PREFIX?=/usr/local
+MANDIR?=$(PREFIX)/man
 INSTGROUP?=wheel
 ifneq ($(OS),Darwin)
 LDLIBS?=-lpthread -lutil
 endif
 endif
-BINDIR?=$(DESTDIR)/bin
-MANDIR?=$(DESTDIR)/share/man
+DESTDIR?= ""
+BINDIR?=$(PREFIX)/bin
 
 objects=kplex.o fileio.o serial.o bcast.o tcp.o options.o error.o lookup.o mcast.o gofree.o udp.o
 
@@ -43,13 +44,14 @@ version.h:
 	@echo '#define VERSION "'$(BASE_VERSION)'"' > version.h
 
 install: kplex
-	test -d "$(BINDIR)"  || install -d -g $(INSTGROUP) -o root -m 755 $(BINDIR)
-	install -g $(INSTGROUP) -o root -m 755 kplex $(BINDIR)/kplex
-	test -d $(MANDIR)/man1 && gzip -c kplex.1 > $(MANDIR)/man1/kplex.1.gz
+	test -d $(DESTDIR)$(BINDIR)  || install -d -g $(INSTGROUP) -o root -m 755 $(DESTDIR)$(BINDIR)
+	install -g $(INSTGROUP) -o root -m 755 kplex $(DESTDIR)$(BINDIR)/kplex
+	test -d $(DESTDIR)$(MANDIR)/man1 || install -d -g $(INSTGROUP) -o root -m 755 $(DESTDIR)$(MANDIR)/man1
+	gzip -c kplex.1 > $(DESTDIR)$(MANDIR)/man1/kplex.1.gz
 
 uninstall:
-	-rm -f $(BINDIR)/kplex
-	-rm -f $(MANDIR)/man1/kplex.1.gz
+	-rm -f $(DESTDIR)$(BINDIR)/kplex
+	-rm -f $(DESTDIR)$(MANDIR)/man1/kplex.1.gz
 
 clean:
 	-rm -f kplex $(objects)


### PR DESCRIPTION
When creating sources to upload to PPA for distribution in ubuntu and debian, a local installation has to be done and DESTDIR gets overrided by the local path. Replacing DESTDIR by PREFIX allows DESTDIR to work locally and be compiled manually as usual too. man1 path had also to be created if not exists to avoid errors.

After modifications the package can be built and shared and kplex and man are working right
https://launchpad.net/~sailoog/+archive/ubuntu/openplotter