### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,4 @@ RUN make install /app
 RUN rm -r /app
 
 # Entrypoint
-CMD /usr/bin/kplex -o mode=background
-
-
-# Build image with:
-# docker build -t kplex .
+CMD /usr/bin/kplex

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:10-slim
+
+# RUN apt-get update && apt-get install build-essential
+
+# Install kplex
+COPY . /app
+RUN make /app
+RUN make install /app
+
+# Remove source code
+RUN rm -r /app
+
+# Entrypoint
+CMD /usr/bin/kplex -o mode=background

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ RUN apt-get update \
 # Do not verify certificates
 RUN git config --global http.sslverify false
 
-# make install needs this directory
-RUN mkdir /usr/share/man/man1
-
 # Install kplex
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
 FROM debian:10-slim
 
-# RUN apt-get update && apt-get install build-essential
+# Install build tools
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Do not verify certificates
+git config --global http.sslverify false
+
+# make install needs this directory
+RUN mkdir /usr/share/man/man1
 
 # Install kplex
-COPY . /app
+WORKDIR /app
+COPY . .
 RUN make /app
 RUN make install /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Do not verify certificates
-git config --global http.sslverify false
+RUN git config --global http.sslverify false
 
 # make install needs this directory
 RUN mkdir /usr/share/man/man1
@@ -22,3 +22,7 @@ RUN rm -r /app
 
 # Entrypoint
 CMD /usr/bin/kplex -o mode=background
+
+
+# Build image with:
+# docker build -t kplex .

--- a/README
+++ b/README
@@ -60,6 +60,18 @@ in this README file for how to create a confiuration file.  A quick start
 example which bridges between a tcp server and a 38400 baud serial-to-usb
 connection is commented out in this example file.
 
+Installation with Docker
+------------------------
+You can build the docker image by cloning the repository and running `docker build -t kplex .`.
+
+Using Docker Compose
+--------------------
+Copy the `kplex.conf.ex` file to `kplex.conf` and define the default options as described in the next section. 
+
+If you have configured a TCP/UDP port you need to open this port in `docker-compose.yml` by uncomment/modify the port section.
+
+In case you are using a usb device you need to route the device to the container. Open the `docker-compose.yml`, uncomment and modify the volume pointing to `/dev`. You also need to uncomment `privileged: true` in ordeer for the container to access the `/dev` directory.
+
 Invocation:
 -----------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
                
     kplex:
         image: kplex:latest
-        build: https://github.com/stripydog/kplex.git # ToDo: change to stripydog repo after merge
+        build: https://github.com/stripydog/kplex.git
         container_name: kplex
         restart: always       
 #        ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
                
     kplex:
         image: kplex:latest
-        build: .
+        build: https://github.com/jwillmer/kplex.git # ToDo: change to stripydog repo after merge
         container_name: kplex
         restart: always       
 #        ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.5"
+
+services:
+               
+    kplex:
+        image: kplex:latest
+        build: .
+        container_name: kplex
+        restart: always       
+#        ports:
+#            - "10110:10110"
+        volumes:
+            - ./kplex.conf:/etc/kplex.conf:ro # kplex.conf needs to be created first
+#            - /dev:/dev/ttyUSB0 # filename=<device>    
+#        privileged: true            

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
                
     kplex:
         image: kplex:latest
-        build: https://github.com/jwillmer/kplex.git # ToDo: change to stripydog repo after merge
+        build: https://github.com/stripydog/kplex.git # ToDo: change to stripydog repo after merge
         container_name: kplex
         restart: always       
 #        ports:


### PR DESCRIPTION
- Dockerfile for building the app as a container
- docker-compose example
- Update of readme

After merge:
Go into cocker-compose.yml and change repository url.

Future:
Think about deploying the image on [docker hub](https://hub.docker.com/). If it is deployed on docker hub you can remove the build command in the docker-compose file and rename the image to  `stripydog/kplex:latest` (if you use stripydog as account name in docker hub)