### PR TITLE
fix default prefix location for linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 OS=$(shell uname -s)
+PREFIX?=/usr/local
 ifneq ("$(wildcard .git)","")
 CFLAGS?=-g -Wall
 VERSION := $(shell git describe --dirty --tags | sed 's/^v//')
@@ -17,7 +18,7 @@ ifneq ($(OS),Darwin)
 LDLIBS?=-lpthread -lutil
 endif
 endif
-PREFIX?=/usr/local
+
 DESTDIR?= ""
 BINDIR?=$(PREFIX)/bin
 SHAREDIR=$(PREFIX)/share/kplex

--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,17 @@ else
 BASE_VERSION := $(shell cat base_version)
 endif
 ifeq ($(OS),Linux)
-PREFIX?=/usr
 MANDIR?=$(PREFIX)/share/man
 LDLIBS?=-pthread -lutil
 INSTGROUP?=root
 else
-PREFIX?=/usr/local
 MANDIR?=$(PREFIX)/man
 INSTGROUP?=wheel
 ifneq ($(OS),Darwin)
 LDLIBS?=-lpthread -lutil
 endif
 endif
+PREFIX?=/usr/local
 DESTDIR?= ""
 BINDIR?=$(PREFIX)/bin
 SHAREDIR=$(PREFIX)/share/kplex


### PR DESCRIPTION
Under linux every binary that are not provided by a package manager should be under a local/ folder. 

Default value should expect manual build As each Distro have it's own package builder that will launch the makefile from their own build procedure. it's in their role to define the prefix used in their respective distro.