### PR TITLE
Enable 921600bps serial

### DIFF
--- a/README
+++ b/README
@@ -224,7 +224,7 @@ normally want RS232 input.
             <device> is the serial device (e.g. /dev/ttyS0)
             <baud> is the baud rate.  Defaults to 4800 if unspecified
             Supported baud rates are: 4800, 9600, 19200, 38400, 57600, 115200,
-            230400 and 460800.
+            230400, 460800, and 921600.
 
 You must minimally specify a device name for a serial interface.  usb to serial
 converters often use /dev/ttyUSB0. Check your /var/adm/messages file and/or udev

--- a/serial.c
+++ b/serial.c
@@ -324,6 +324,10 @@ struct iface *init_serial (struct iface *ifa)
             else if (!strcmp(opt->val,"460800"))
                 baud=B460800;
 #endif
+#ifdef B921600
+            else if (!strcmp(opt->val,"921600"))
+                baud=B921600;
+#endif
             else {
                 logerr(0,catgets(cat,8,15,
                         "Unsupported baud rate \'%s\' in interface specification '\%s\'"),


### PR DESCRIPTION
Tiny change to enable 921600bps serial.

Tested and working on my x86_64 Linux machine.

I closed and reopened this pull request after rebasing my change to develop.